### PR TITLE
支持分页加载

### DIFF
--- a/src/components/txGuess.vue
+++ b/src/components/txGuess.vue
@@ -1,6 +1,6 @@
 <template>
   <view class="caption">
-    <text class="text">猜你喜欢</text>
+    <text class="text">{{ guessLikeText }}</text>
   </view>
   <view class="guess">
     <navigator
@@ -24,7 +24,7 @@
 
     </navigator>
   </view>
-   <view class="loading-text"> 正在加载... </view>
+   <view class="loading-text">{{ loadText }}</view>
 </template>
 
 <script lang="ts" setup>
@@ -39,6 +39,8 @@ import { onLoad } from "@dcloudio/uni-app";
 // const props = defineProps<{
 //   list:guessLikeItems<GuessItem>[]
 // }>()
+const guessLikeText = ref('猜你喜欢')
+const loadText = ref('加载中...')
 const pageParams:Required<pageParams>= {
   page:1,
   pageSize:10

--- a/src/components/txGuess.vue
+++ b/src/components/txGuess.vue
@@ -1,0 +1,147 @@
+<template>
+  <view class="caption">
+    <text class="text">猜你喜欢</text>
+  </view>
+  <view class="guess">
+    <navigator
+        open-type="navigate"
+        hover-class="navigator-hover"
+        class="guess-item"
+        v-for="item in guessLikeList"
+        :key="item.id"
+        :url="`/pages/goods/goods?id=4007498`"
+    >
+    <image
+    class="image"
+        :src=item.picture
+        mode="scaleToFill"
+    />
+     <view class="name"> {{ item.name }}</view>
+    <view class="price">
+        <text class="small">¥</text>
+        <text>{{ item.price }}</text>
+      </view>
+
+    </navigator>
+  </view>
+   <view class="loading-text"> 正在加载... </view>
+</template>
+
+<script lang="ts" setup>
+
+import { ref,defineProps, onMounted ,defineExpose} from "vue";
+import type {guessLikeItems} from '@/types/home'
+import type { GuessItem,pageParams } from '@/types/global'
+import {
+  getGuessLikeApi,
+} from "@/services/home";
+import { onLoad } from "@dcloudio/uni-app";
+// const props = defineProps<{
+//   list:guessLikeItems<GuessItem>[]
+// }>()
+const pageParams:Required<pageParams>= {
+  page:1,
+  pageSize:10
+}
+const guessLikeList = ref<GuessItem[]>([])
+const finish = ref(false)
+const getGuessLike = async () => {
+  if(finish.value === true){
+    return uni.showToast({ icon: 'none', title: '没有更多数据'})
+  }
+  let res = await getGuessLikeApi(pageParams);
+  guessLikeList.value.push(...res.result.items)
+
+  if(pageParams.page < res.result.pages){
+    pageParams.page++
+  }else{
+    // 数据加载完了
+    finish.value = true
+  }
+
+};
+
+// 组件挂载时调用方法
+onMounted(()=>{
+  getGuessLike()
+})
+// 暴露方法供外部使用
+defineExpose({
+  getMoreData:getGuessLike
+})
+</script>
+
+<style lang="scss">
+.caption{
+  display: flex;
+  justify-content: center; // 水平居中
+  line-height: 1;
+  padding: 36rpx 0 40rpx;
+  font-size:32rpx;
+  color:black;
+  .text{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0 28rpx 0 30rpx;
+
+    &::before,&::after{
+      content: '';
+      width: 20rpx;
+      height: 20rpx;
+      background-image: url(@/static/images/bubble.png);
+      background-size:contain;
+      margin:0 10rpx
+    }
+
+  }
+
+}
+.guess{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: 0 20rpx;
+  .guess-item {
+    width: 345rpx;
+    padding: 24rpx 20rpx 20rpx;
+    margin-bottom: 20rpx;
+    border-radius: 10rpx;
+    overflow: hidden;
+    background-color: #fff;
+  }
+  .image {
+    width: 304rpx;
+    height: 304rpx;
+  }
+   .name {
+    height: 75rpx;
+    margin: 10rpx 0;
+    font-size: 26rpx;
+    color: #262626;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    // display: -webkit-box;
+    // -webkit-line-clamp: 2;
+    // -webkit-box-orient: vertical;
+  }
+    .price {
+    line-height: 1;
+    padding-top: 4rpx;
+    color: #cf4444;
+    font-size: 26rpx;
+  }
+  .small {
+    font-size: 80%;
+  }
+}
+// 加载提示文字
+.loading-text {
+  text-align: center;
+  font-size: 28rpx;
+  color: #666;
+  padding: 20rpx 0;
+}
+
+
+</style>

--- a/src/components/txSwiper.vue
+++ b/src/components/txSwiper.vue
@@ -28,8 +28,6 @@ import { ref,defineProps } from "vue";
 import type { bannerItem } from '@/types/home'
 const activeIndex = ref(0)
 const onchange : UniHelper.SwiperOnChange= (val)=>{
-  // const event = val.detail as {current:string}
-  console.log(val.detail.current)
   activeIndex.value = val.detail.current
 
 }

--- a/src/pages/index/index.vue
+++ b/src/pages/index/index.vue
@@ -1,50 +1,79 @@
 <script setup lang="ts">
-import { onLoad } from '@dcloudio/uni-app';
-import cutomNavbar  from './components/cutomNavbar.vue';
-import { getHomeBannerApi,getClassifyApi,getHotApi } from '@/services/home';
-import {ref} from 'vue'
-import type { bannerItem ,classifyItems,hotItems} from '@/types/home'
-import categoryPanel from './components/categoryPanel.vue';
-import HotPanel from './components/HotPanel.vue';
+import { onLoad } from "@dcloudio/uni-app";
+import cutomNavbar from "./components/cutomNavbar.vue";
+import {
+  getHomeBannerApi,
+  getClassifyApi,
+  getHotApi,
+} from "@/services/home";
+import { ref } from "vue";
+import type {
+  bannerItem,
+  classifyItems,
+  hotItems,
+  guessLikeItems,
+} from "@/types/home";
+import type { GuessItem } from '@/types/global'
 
-const bannerList = ref<bannerItem[]>([])
-const classifyList = ref<classifyItems[]>([])
-const hotList = ref<hotItems[]>([])
+import categoryPanel from "./components/categoryPanel.vue";
+import HotPanel from "./components/HotPanel.vue";
+import type {guessInterface} from '@/types/component'
+const bannerList = ref<bannerItem[]>([]);
+const classifyList = ref<classifyItems[]>([]);
+const hotList = ref<hotItems[]>([]);
 //获取轮播图数据
-const getHomeBanner = async ()=>{
-  let res = await getHomeBannerApi()
-  bannerList.value = res.result
-}
+const getHomeBanner = async () => {
+  let res = await getHomeBannerApi();
+  bannerList.value = res.result;
+};
 //获取分类数据
-const getClassify  = async()=>{
-  let res = await getClassifyApi()
-  classifyList.value = res.result
-}
+const getClassify = async () => {
+  let res = await getClassifyApi();
+  classifyList.value = res.result;
+};
 // 获取热门推荐数据
-const getHotData = async()=>{
-  let res = await getHotApi()
-  hotList.value = res.result
-  console.log(res)
-}
+const getHotData = async () => {
+  let res = await getHotApi();
+  hotList.value = res.result;
+};
+
 // 页面加载时候的生命周期
-onLoad(()=>{
-  getHomeBanner()
-  getClassify()
-  getHotData()
-})
+onLoad(() => {
+  getHomeBanner();
+  getClassify();
+  getHotData();
+  // getGuessLike();
+});
+const guessref = ref<guessInterface>() // 需要定义组件的实例类型
+//滚动触底
+const scrolltolower = ()=>{
+  // 调用子组件方法，继续获取数据
+  console.log('123')
+  guessref.value?.getMoreData()
+
+}
 </script>
 
 <template>
   <!-- 导航栏 搜索栏 -->
-  <cutomNavbar/>
-  <txSwiper :list="bannerList"></txSwiper>
-  <categoryPanel :list = "classifyList"></categoryPanel>
-  <HotPanel :list="hotList"></HotPanel>
+  <cutomNavbar />
+  <scroll-view @scrolltolower="scrolltolower" scroll-y class="scroll-view" >
+    <txSwiper :list="bannerList"></txSwiper>
+    <categoryPanel :list="classifyList"></categoryPanel>
+    <HotPanel :list="hotList"></HotPanel>
+    <txGuess ref="guessref"></txGuess>
+  </scroll-view>
 </template>
 
 <style lang="scss">
-.pages{
-  background-color:#F6F6F6;
+page {
+  background-color: #f6f6f6;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
-
+.scroll-view {
+  //当希望某个区域自动填充剩余空间时
+  flex: 1;
+}
 </style>

--- a/src/pages/index/index.vue
+++ b/src/pages/index/index.vue
@@ -48,16 +48,33 @@ const guessref = ref<guessInterface>() // 需要定义组件的实例类型
 //滚动触底
 const scrolltolower = ()=>{
   // 调用子组件方法，继续获取数据
-  console.log('123')
   guessref.value?.getMoreData()
 
+}
+const refresherTriggered = ref(false)
+// 下拉刷新触发
+const refresh = async()=>{
+  refresherTriggered.value = true
+  // 重新加载一遍页面
+  // 把数据都清除，重新加载
+  // await getHomeBanner();
+  // await getClassify();
+  // await getHotData();
+  await Promise.all([getHomeBanner(),getClassify(), getHotData()])
+  refresherTriggered.value = false
+  console.log('refresherTriggered',refresherTriggered)
+
+}
+//下拉刷新复位
+const refresherRestore = ()=>{
+  console.log('refresherRestore')
 }
 </script>
 
 <template>
   <!-- 导航栏 搜索栏 -->
   <cutomNavbar />
-  <scroll-view @scrolltolower="scrolltolower" scroll-y class="scroll-view" >
+  <scroll-view refresher-enabled refresher-triggered="refresherTriggered" @refresherrestore="refresherRestore" @refresherrefresh="refresh" @scrolltolower="scrolltolower" scroll-y class="scroll-view" >
     <txSwiper :list="bannerList"></txSwiper>
     <categoryPanel :list="classifyList"></categoryPanel>
     <HotPanel :list="hotList"></HotPanel>

--- a/src/services/home.ts
+++ b/src/services/home.ts
@@ -1,27 +1,41 @@
 import { http } from "@/utils/http";
-import type { bannerItem, classifyItems, hotList } from '@/types/home'
+import type {
+    bannerItem,
+    classifyItems,
+    hotItems,
+    guessLikeItems,
+
+} from "@/types/home";
+import type { GuessItem, pageParams } from '@/types/global'
 // 投放的区域位置distributionSite，1 放在主页，2 放在商品页
 export const getHomeBannerApi = (distributionSite = 1) => {
     return http<bannerItem[]>({
-        method: 'GET',
-        url: '/home/banner',
+        method: "GET",
+        url: "/home/banner",
         data: {
-            distributionSite,// 接口定义的入参
-        }
-    })
-}
+            distributionSite, // 接口定义的入参
+        },
+    });
+};
 
 export const getClassifyApi = () => {
     return http<classifyItems[]>({
-        method: 'GET',
-        url: '/home/category/mutli'
-
-    })
-}
+        method: "GET",
+        url: "/home/category/mutli",
+    });
+};
 
 export const getHotApi = () => {
-    return http<hotList[]>({
-        method: 'GET',
-        url: '/home/hot/mutli'
-    })
-}
+    return http<hotItems[]>({
+        method: "GET",
+        url: "/home/hot/mutli",
+    });
+};
+
+export const getGuessLikeApi = (data: pageParams) => {
+    return http<guessLikeItems<GuessItem>>({
+        method: "GET",
+        url: "/home/goods/guessLike",
+        data
+    });
+};

--- a/src/types/component.d.ts
+++ b/src/types/component.d.ts
@@ -5,11 +5,18 @@
  */
 import 'vue'
 import txSwiper from '@/components/txSwiper.vue'
+import txGuess from '@/components/txGuess.vue'
 
 declare module 'vue' {
   //**全局组件类型声明** //导入组件时会有类型提示
   export interface GlobalComponents {
     txSwiper: typeof txSwiper
+    txGuess: typeof txGuess
+
     //
   }
 }
+
+// 组件实例类型
+
+export type guessInterface = InstanceType<typeof txGuess>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,15 @@
+
+
+export type GuessItem = {
+    desc: string
+    id: string
+    name: string
+    orderNum: number
+    picture: string
+    price: string
+}
+/** 通用分页参数类型 */
+export type pageParams = {
+    page: number,
+    pageSize: number
+}

--- a/src/types/home.d.ts
+++ b/src/types/home.d.ts
@@ -1,3 +1,4 @@
+import type exp from "constants"
 
 // 类型说明文件，定义获取到的轮播图数据的类型
 export type bannerItem = {
@@ -30,3 +31,14 @@ export type hotItems = {
     title: string
     type: number
 }
+
+export type guessLikeItems<T> = {
+    counts: number
+    items: T[]
+    page: number
+    pageSize: number
+    pages: number
+}
+
+
+


### PR DESCRIPTION
封装实例类型 InstanceType
封装通用分页类型
支持下拉触底后调用接口继续获取数据
子组件暴露方法供父组件使用
父组件获取子组件实例，通过 ref
页面布局：使用scroll-view 包裹除搜索栏外的组件，下滑过程中，保存搜索栏固定 ==>flex:1
泛型嵌套
